### PR TITLE
Upgrade mysql in docker-compose to 8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - db-mysql
 
   db-mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     command: mysqld --sql_mode=""
     container_name: db_mysql
     ports: 


### PR DESCRIPTION
mysql 5.7 isnt available for arm, it will fail to run in arm based (m1), thats why mysql need to be in the version that support arm